### PR TITLE
chore: update ruff.toml

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,6 +8,30 @@ target-version = "py39"
 include = ["**/pyproject.toml", "*.py", "*.pyi"]
 extend-include = ["*.ipynb"]
 
+# Exclude a variety of commonly ignored directories (you can have some problems)
+exclude = [
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    ".venv"
+]
+
+[lint]
 # Rules: https://beta.ruff.rs/docs/rules/
 # Enable Pyflakes `E` and `F` codes by default.
 select = [
@@ -48,30 +72,9 @@ ignore = [
 fix = true
 fixable = ["ALL"]
 unfixable = ["F401"]
+
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = ">=(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-# Exclude a variety of commonly ignored directories (you can have some problems)
-exclude = [
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".hg",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
-    ".venv"
-]
 
 [format]
 # select = ["E4", "E7", "E9", "F"]
@@ -82,19 +85,19 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
 
-[mccabe]
+[lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 
-[flake8-quotes]
+[lint.flake8-quotes]
 docstring-quotes = "double"
 
-[pydocstyle]
+[lint.pydocstyle]
 convention = "google"
 
-[isort]
+[lint.isort]
 known-third-party = ["fastapi", "pydantic", "starlette"]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "__init__.py" = ["D104", "F401", "I002"]
 "test*.py"    = ["S101", "T201"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -64,13 +64,11 @@ ignore = [
     "D213",   # Multi-line docstring summary should start at the second line
     "D417",   # Missing argument description in the docstring for {definition}: {name}
     "E501",   # Line too long ({width} > {limit} characters)
-    "E501",   # line too long, handled by black
     "D100",
 ]
 
 # Always autofix, but never try to fix `F401` (unused imports).
 fix = true
-fixable = ["ALL"]
 unfixable = ["F401"]
 
 # Allow unused variables when underscore-prefixed.

--- a/{{cookiecutter.directory_name}}/.ruff.toml
+++ b/{{cookiecutter.directory_name}}/.ruff.toml
@@ -8,6 +8,30 @@ target-version = "py39"
 include = ["**/pyproject.toml", "*.py", "*.pyi"]
 extend-include = ["*.ipynb"]
 
+# Exclude a variety of commonly ignored directories (you can have some problems)
+exclude = [
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    ".venv"
+]
+
+[lint]
 # Rules: https://beta.ruff.rs/docs/rules/
 # Enable Pyflakes `E` and `F` codes by default.
 select = [
@@ -40,38 +64,15 @@ ignore = [
     "D213",   # Multi-line docstring summary should start at the second line
     "D417",   # Missing argument description in the docstring for {definition}: {name}
     "E501",   # Line too long ({width} > {limit} characters)
-    "E501",   # line too long, handled by black
     "D100",
 ]
 
 # Always autofix, but never try to fix `F401` (unused imports).
 fix = true
-fixable = ["ALL"]
 unfixable = ["F401"]
+
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = ">=(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-# Exclude a variety of commonly ignored directories (you can have some problems)
-exclude = [
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".hg",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
-    ".venv"
-]
 
 [format]
 # select = ["E4", "E7", "E9", "F"]
@@ -82,19 +83,19 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
 
-[mccabe]
+[lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 
-[flake8-quotes]
+[lint.flake8-quotes]
 docstring-quotes = "double"
 
-[pydocstyle]
+[lint.pydocstyle]
 convention = "google"
 
-[isort]
+[lint.isort]
 known-third-party = ["fastapi", "pydantic", "starlette"]
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "__init__.py" = ["D104", "F401", "I002"]
 "test*.py"    = ["S101", "T201"]


### PR DESCRIPTION
Summary:
- 4a40d76686b8050e35767af76ea5266e9c7fa68d:
    - update `ruff.toml` by nesting _linter-specific_ configs under `[lint]` (and related); though it would work (or, actually, works) the way it currently is, the proposed one could be a preferable/more future-proof option in sight of the upcoming deprecation of top-level lint settings discussed in https://github.com/astral-sh/ruff/issues/8449 or https://github.com/astral-sh/ruff/issues/7651
- e98932459004b575efff18fc150a6b1b4960a802:
    - `fixable = ["ALL"]` is the default already as per https://docs.astral.sh/ruff/settings/#fixable. In my understanding, `fixable` should be rather used to specify those rules - among the ones to be _checked_ - that one wants to _autofix_ as well (provided that an autofix is _available_ and _not unsafe_)
    - remove duplicate from `ignore` list
- 7f66f96fbab067282b00d90c4f1a23e13a7fdfee:
    - copy changes under `cookiecutter` directory

PS: I'm not sure I correctly followed the contributing guidelines. The generated `testone` project didn't seem to embed the changes I committed before generating it; anyway, such configuration works on my side and should be backed by Ruff's docs as well